### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,32 @@
-# Getting Started with Create React App
+Opencast Video Editor
+=====================
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+[![Build & Deploy](https://github.com/elan-ev/opencast-editor/workflows/Build%20&%20Deploy/badge.svg)
+](https://github.com/elan-ev/opencast-editor/actions?query=workflow%3A%22Build+%26+Deploy%22)
+[![Demo deployment](https://img.shields.io/badge/demo-editor.opencast.org-blue)
+](https://editor.opencast.org)
 
-## Available Scripts
+The Opencast Video Editor is a stand-alone tool included by [Opencast](https://opencast.org) to cut and arrange recordings.
+
+
+Quick Test
+----------
 
 In the project directory, you can run:
 
-### `npm start`
+    npm start
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+This will run the app in the development mode.
+Open [http://localhost:3000](localhost:3000) to view it in the browser.
 
-The page will reload if you make edits.\
-You will also see any lint errors in the console.
 
-### `npm test`
+Building the Editor
+-------------------
 
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+To build the editor for production to the `build` folder, run:
 
-### `npm run build`
+    npm run build
 
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
+To make the editor work in a sub-path, use:
 
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
+    PUBLIC_URL=/path npm run build


### PR DESCRIPTION
This patch adds a basic readme for the editor, replacing the generic
create-react-app readme. It just contains a few links and some build
information for now.