### PR TITLE
Timeline Border

### DIFF
--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -31,7 +31,6 @@ const Timeline: React.FC<{}> = () => {
 
   const timelineStyle = css({
     position: 'relative' as 'relative',     // Need to set position for Draggable bounds to work
-    borderRadius: '10px',
     backgroundColor: 'snow',
     height: '250px',
     width: '100%',
@@ -195,9 +194,9 @@ const SegmentsList: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
       segments.map( (segment: Segment, index: number) => (
         <div key={segment.id} title="Segment" css={{
           backgroundColor: bgColor(segment.isAlive, activeSegmentIndex === index),//segment.state === "alive" ? 'rgba(0, 0, 255, 0.4)' : 'rgba(255, 0, 0, 0.4)',
-          borderRadius: '15px',
+          borderRadius: '5px',
           borderStyle: 'solid',
-          borderColor: segment.isAlive ? 'blue' : 'red',
+          borderColor: 'white',
           borderWidth: '1px',
           boxSizing: 'border-box',
           width: ((segment.endTime - segment.startTime) / duration) * 100 + '%',


### PR DESCRIPTION
This patch reduces the border radius and turns the border a consistent
white color.

Reasoning:

- the border radius looked a bit odd with the scrubber extending over the edge
- the different colored borders looked somewhat odd when you had deleted
  and non-deleted segments right next to each other
- the white border causes a clean separation of segments

This supersedes #20