### PR TITLE
Fixed horizontal overflow (Shows scrollbar)

### DIFF
--- a/src/main/MainContent.tsx
+++ b/src/main/MainContent.tsx
@@ -25,7 +25,6 @@ const MainContent: React.FC<{}> = () => {
   const mainMenuState = useSelector(selectMainMenuState)
 
   const cuttingStyle = css({
-    width: '100%',
     display: mainMenuState !== MainMenuStateNames.cutting ? 'none' :'flex',
     flexDirection: 'column' as const,
     justifyContent: 'space-around',
@@ -36,7 +35,6 @@ const MainContent: React.FC<{}> = () => {
 
   const saveProcessCancelStyle = css({
     display: mainMenuState !== MainMenuStateNames.finish ? 'none' : 'flex',
-    width: '100%',
     flexDirection: 'column' as const,
     justifyContent: 'space-around',
     gap: "20px",


### PR DESCRIPTION
This PR fixes issue #44 by removing "width=100%".  As flex items grow to fill the container anyway, explicitly setting the width is no longer necessary.