### PR TITLE
Added wrapper around video players to limit video-height

### DIFF
--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -134,18 +134,26 @@ const VideoPlayer: React.FC<{url: string, isMuted: boolean}> = ({url, isMuted}) 
     }
   })
 
+  const playerWrapper = css({
+    backgroundColor: 'rgba(255,255,255,1)',
+    width: '100%',
+    height: '50vh'
+  });
+
   return (
-    <ReactPlayer url={url}
-      ref={ref}
-      width='100%'
-      height='auto'
-      playing={isPlaying}
-      muted={isMuted}
-      onProgress={onProgressCallback}
-      progressInterval={100}
-      onReady={onReadyCallback}
-      onEnded={onEndedCallback}
-    />
+    <div css={playerWrapper} title="playerWrapper">
+      <ReactPlayer url={url}
+        ref={ref}
+        width='100%'
+        height='100%'
+        playing={isPlaying}
+        muted={isMuted}
+        onProgress={onProgressCallback}
+        progressInterval={100}
+        onReady={onReadyCallback}
+        onEnded={onEndedCallback}
+      />
+    </div>
   );
 
   // return (

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -135,7 +135,6 @@ const VideoPlayer: React.FC<{url: string, isMuted: boolean}> = ({url, isMuted}) 
   })
 
   const playerWrapper = css({
-    backgroundColor: 'rgba(255,255,255,1)',
     width: '100%',
     height: '50vh'
   });


### PR DESCRIPTION
This PR should be a suitable solution for #22. It adds a wrapper around the video player and sets its height to 50% of the current viewport. This should prevent videos from overscaling.