### PR TITLE
Allows passing a mediaPackageId for testing

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,4 +5,11 @@
 /**
  * Hardcoded id of the mediapackge the editor will work on
  */
-export const mediaPackageId : string = "e63706bc-48df-4346-a72a-bf6f39cea32c"
+export var mediaPackageId : string = "e63706bc-48df-4346-a72a-bf6f39cea32c"
+var urlParams = new URLSearchParams(window.location.search);
+if (urlParams.has("mediaPackageId")) {
+  let tmp = urlParams.get("mediaPackageId")
+  if (tmp) {
+    mediaPackageId = tmp
+  }
+}


### PR DESCRIPTION
You can now pass an id in the form of `?mediaPackageId=838b9eb3-d44e-47a1-b69e-b10e65b4ec92` to the editor to load the mediapackage you want.