### PR TITLE
Replaced icon for preview mode with text

### DIFF
--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -6,7 +6,7 @@ import { httpRequestState } from '../types'
 import { mediaPackageId } from '../config'
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPlay, faPause, faToggleOn, faToggleOff, faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+import { faPlay, faPause, faToggleOn, faToggleOff} from "@fortawesome/free-solid-svg-icons";
 
 import { useSelector, useDispatch } from 'react-redux';
 import {

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -228,8 +228,10 @@ const VideoControls: React.FC<{}> = () => {
   return (
     <div css={videoControlStyle} title="Video Controls">
       <div css={videoControlsRowStyle} title="Video Controls Top Row">
-        <div css={{display: 'flex', gap: '10px', width: '50px', justifyContent: 'center'}}>
-          <FontAwesomeIcon icon={isPlayPreview ? faEyeSlash : faEye} size="1x" title="Play Preview Icon"/>
+        <div css={{display: 'flex', gap: '10px', justifyContent: 'center', alignItems: 'center'}}>
+          <div css={{display: 'inline-block', flexWrap: 'nowrap'}}>
+            Preview Mode
+          </div>
           <FontAwesomeIcon css={playPreviewStyle} icon={isPlayPreview ? faToggleOn : faToggleOff} size="1x"
             title={"Play Preview Switch: " + isPlayPreview}
             role="switch" aria-checked={isPlayPreview} tabIndex={0}


### PR DESCRIPTION
This change is intended to better inform the user what the preview mode switch is about. As there is no icon distinctly representing such a feature, text is preferred.