### PR TITLE
Disables Picture-in-Picture Mode for video players

### DIFF
--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -146,8 +146,8 @@ const VideoPlayer: React.FC<{url: string, isMuted: boolean}> = ({url, isMuted}) 
       progressInterval={100}
       onReady={onReadyCallback}
       onEnded={onEndedCallback}
-      pip={false}
       tabIndex={-1}
+      disablePictureInPicture
     />
   );
 


### PR DESCRIPTION
PiP grants users single video controls, which we do not want (everything should be controlled centrally).
Therefore, this PR disables PiP.
Except in Firefox, because Firefox doesn't want PiP to be disabled.