### PR TITLE
Shorten and align save and discard

### DIFF
--- a/src/main/Discard.tsx
+++ b/src/main/Discard.tsx
@@ -31,9 +31,9 @@ const Discard : React.FC<{}> = () => {
 
   return (
     <div css={cancelStyle} title="Abort Area">
+      <h1>Discard changes</h1>
       <span>
-        Discard all the changes you made? This cannot be undone! <br />
-        Do you truly want all your changes to be lost forever?
+        Discard all the changes you made? This cannot be undone!
       </span>
       <div css={backOrContinueStyle}>
         <PageButton pageNumber={0} label="No, take me back" iconName={faChevronLeft} />

--- a/src/main/Save.tsx
+++ b/src/main/Save.tsx
@@ -36,10 +36,10 @@ const Save : React.FC<{}> = () => {
 
   return (
     <div css={saveStyle} title="Save Area">
-      <span>
-        Here you can save the changes you made, but the video will not be cut yet. <br />
-        To make Opencast cut the video, please go back and select "Start processing". <br />
-        Do you truly wish to save?
+      <h1>Save current project</h1>
+      <span css={{maxWidth: '500px'}}>
+        The video will not be processed but all cutting information are stored
+        in Opencast. You can continue your eddi later.
       </span>
       <div css={backOrContinueStyle}>
         <PageButton pageNumber={0} label="No, take me back" iconName={faChevronLeft}/>

--- a/src/main/Save.tsx
+++ b/src/main/Save.tsx
@@ -38,8 +38,8 @@ const Save : React.FC<{}> = () => {
     <div css={saveStyle} title="Save Area">
       <h1>Save current project</h1>
       <span css={{maxWidth: '500px'}}>
-        The video will not be processed but all cutting information are stored
-        in Opencast. You can continue your eddi later.
+        The video will not be processed but all cutting information will be stored
+        in Opencast. You can continue your edit later.
       </span>
       <div css={backOrContinueStyle}>
         <PageButton pageNumber={0} label="No, take me back" iconName={faChevronLeft}/>


### PR DESCRIPTION
This patch shortens the texts for saving and discarding the current
project and add a header alike the one you get when choosing to start
processing.