### PR TITLE
Remove Unhelpful Titles

### DIFF
--- a/src/main/MainContent.tsx
+++ b/src/main/MainContent.tsx
@@ -52,12 +52,12 @@ const MainContent: React.FC<{}> = () => {
 
   return (
      <main title="MainMenuContext" css={{width: '100%'}} role="main">
-      <div css={cuttingStyle} title="Cutting Container">
+      <div css={cuttingStyle}>
           <Video />
           <CuttingActions />
           <Timeline />
       </div>
-      <div css={finishStyle} title="Finish Container">
+      <div css={finishStyle}>
         <Finish />
       </div>
       <div css={defaultStyle}>


### PR DESCRIPTION
It's good to have title for elements you can interact with to provide
additional explanations but these are not helpful to users and provide
no more information except telling developers what element they are
hovering over.