### PR TITLE
Introduced wrapping to the finish menu

### DIFF
--- a/src/main/FinishMenu.tsx
+++ b/src/main/FinishMenu.tsx
@@ -20,6 +20,7 @@ const FinishMenu : React.FC<{}> = () => {
     display: 'flex',
     flexDirection: 'row' as const,
     justifyContent: 'space-around',
+    flexWrap: 'wrap',
     gap: '30px',
   })
 


### PR DESCRIPTION
Allows flexWrap in the finish menu ("Save, Process, Discard") to avoid squishing the large buttons on smaller resolutions.

This is the easiest solution to #129, but may not look as good, since the buttons do not immediately change from row to column. Another solution would be media-queries, but those are require specifying a width and are thus not quite as dynamic.
