### PR TITLE
First basic unit test for reducers of videoSlice

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug CRA Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",
+      "args": ["test", "--runInBand", "--no-cache", "--watchAll=false"],
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "env": { "CI": "true" },
+      "disableOptimisticBPs": true
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2759,6 +2759,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
+    "@types/lodash": {
+      "version": "4.14.168",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.168.tgz",
+      "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -10223,6 +10229,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.flow": {
       "version": "3.5.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "customize-cra": "^1.0.0",
     "deepmerge": "^4.2.2",
     "emotion": "^11.0.0",
+    "lodash.clonedeep": "^4.5.0",
     "react": "^17.0.1",
     "react-app-rewired": "^2.1.8",
     "react-dom": "^17.0.1",
@@ -40,7 +41,8 @@
     "start": "react-app-rewired start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
-    "eject": "react-app-rewired eject"
+    "eject": "react-app-rewired eject",
+    "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache"
   },
   "eslintConfig": {
     "extends": [
@@ -61,6 +63,7 @@
     ]
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.168",
     "redux-devtools": "^3.7.0",
     "use-resize-observer": "^7.0.0"
   }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/redux/__tests__/videoSlice.test.ts
+++ b/src/redux/__tests__/videoSlice.test.ts
@@ -1,0 +1,355 @@
+import reducer, { initialState, setIsPlaying, selectIsPlaying, setCurrentlyAt,
+  selectCurrentlyAt, selectActiveSegmentIndex, selectPreviewTriggered,
+  selectDuration, video, cut, selectSegments, markAsDeletedOrAlive, mergeRight,
+  fetchVideoInformation, selectVideoURL, selectTitle, selectPresenters,
+  selectTracks, selectWorkflows } from '../videoSlice'
+import cloneDeep from 'lodash/cloneDeep';
+import { httpRequestState } from '../../types';
+
+
+describe('Video reducer', () => {
+
+  let initState: (video & httpRequestState);
+
+  beforeEach(() => {
+    initState = cloneDeep(initialState);
+  });
+
+  it('should return the initial state on first run', () => {
+    // Arrange
+    const nextState = initialState;
+
+    // Act
+    const result = reducer(undefined, { type: ''});
+
+    // Assert
+    expect(result).toEqual(nextState);
+  });
+
+  it('should set isPlaying', () => {
+    // Arrange
+    const isPlaying = true
+
+    // Act
+    const nextState = reducer(initState, setIsPlaying(isPlaying))
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectIsPlaying(rootState)).toEqual(true);
+  })
+
+  it('should set currentlyAt', () => {
+    // Arrange
+    const currentlyAt = 0
+
+    // Act
+    const nextState = reducer(initState, setCurrentlyAt(currentlyAt))
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectCurrentlyAt(rootState)).toEqual(0);
+    expect(selectActiveSegmentIndex(rootState)).toEqual(0);
+    expect(selectPreviewTriggered(rootState)).toEqual(false);
+  })
+
+  it('only allow whole numbers for currentlyAt', () => {
+    // Arrange
+    const currentlyAt = 123.456
+
+    // Act
+    const nextState = reducer(initState, setCurrentlyAt(currentlyAt))
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectCurrentlyAt(rootState)).toEqual(123);
+    expect(selectActiveSegmentIndex(rootState)).toEqual(0);
+    expect(selectPreviewTriggered(rootState)).toEqual(false);
+  })
+
+  it('should not set currentlyAt to negative', () => {
+    // Arrange
+    const currentlyAt = -42
+
+    // Act
+    const nextState = reducer(initState, setCurrentlyAt(currentlyAt))
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectCurrentlyAt(rootState)).toEqual(0);
+    expect(selectActiveSegmentIndex(rootState)).toEqual(0);
+    expect(selectPreviewTriggered(rootState)).toEqual(false);
+  })
+
+  it('should not set currentlyAt larger than duration', () => {
+    // Arrange
+    const currentlyAt = 43
+    initState.duration = 42
+
+    // Act
+    const nextState = reducer(initState, setCurrentlyAt(currentlyAt))
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectCurrentlyAt(rootState)).toEqual(42);
+    expect(selectActiveSegmentIndex(rootState)).toEqual(0);
+    expect(selectPreviewTriggered(rootState)).toEqual(false);
+  })
+
+  it('should change the activeSegment when setting currentlyAt', () => {
+    // Arrange
+    const currentlyAt = 15
+    initState.duration = 30
+    initState.segments = [
+      {id: '0', start: 0, end: 10, deleted: false},
+      {id: '0', start: 10, end: 20, deleted: false},
+      {id: '0', start: 20, end: 30, deleted: false},
+    ]
+
+    // Act
+    const nextState = reducer(initState, setCurrentlyAt(currentlyAt))
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectCurrentlyAt(rootState)).toEqual(15);
+    expect(selectActiveSegmentIndex(rootState)).toEqual(1);
+    expect(selectPreviewTriggered(rootState)).toEqual(false);
+  })
+
+  it(`should set currentlyAt to end of segment when preview is active, the video
+      is playing and segment is deleted`, () => {
+    // Arrange
+    const currentlyAt = 15
+    initState.duration = 30
+    initState.segments = [
+      {id: '0', start: 0, end: 10, deleted: false},
+      {id: '0', start: 10, end: 20, deleted: true},
+      {id: '0', start: 20, end: 30, deleted: false},
+    ]
+    initState.isPlaying = true
+    initState.isPlayPreview = true
+
+    // Act
+    const nextState = reducer(initState, setCurrentlyAt(currentlyAt))
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectCurrentlyAt(rootState)).toEqual(20);
+    expect(selectActiveSegmentIndex(rootState)).toEqual(1);
+    expect(selectPreviewTriggered(rootState)).toEqual(true);
+  })
+
+  it('should cut a segment in two', () => {
+    // Arrange
+    initState.currentlyAt = 5
+    initState.duration = 10
+    initState.segments = [
+      {id: '0', start: 0, end: 10, deleted: false},
+    ]
+    let resultSegments = [
+      {start: 0, end: 5, deleted: false},
+      {start: 5, end: 10, deleted: false}
+    ]
+
+    // Act
+    const nextState = reducer(initState, cut())
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectSegments(rootState)).toMatchObject(resultSegments);
+  })
+
+  it('should not cut a segment when exactly at the start', () => {
+    // Arrange
+    initState.currentlyAt = 0
+    initState.duration = 10
+    initState.segments = [
+      {id: '0', start: 0, end: 10, deleted: false},
+    ]
+    let resultSegments = [
+      {start: 0, end: 10, deleted: false},
+    ]
+
+    // Act
+    const nextState = reducer(initState, cut())
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectSegments(rootState)).toMatchObject(resultSegments);
+  })
+
+  it('should not cut a segment when exactly at the end', () => {
+    // Arrange
+    initState.currentlyAt = 10
+    initState.duration = 10
+    initState.segments = [
+      {id: '0', start: 0, end: 10, deleted: false},
+    ]
+    let resultSegments = [
+      {start: 0, end: 10, deleted: false},
+    ]
+
+    // Act
+    const nextState = reducer(initState, cut())
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectSegments(rootState)).toMatchObject(resultSegments);
+  })
+
+  it('should not cut a segment when exactly at the border', () => {
+    // Arrange
+    initState.currentlyAt = 5
+    initState.duration = 10
+    initState.segments = [
+      {id: '0', start: 0, end: 5, deleted: false},
+      {id: '0', start: 5, end: 10, deleted: false}
+    ]
+    let resultSegments = [
+      {start: 0, end: 5, deleted: false},
+      {start: 5, end: 10, deleted: false}
+    ]
+
+    // Act
+    const nextState = reducer(initState, cut())
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectSegments(rootState)).toMatchObject(resultSegments);
+  })
+
+  it('should mark a segment as deleted if alive', () => {
+    let resultSegments = [
+      {deleted: true},
+    ]
+
+    // Act
+    const nextState = reducer(initState, markAsDeletedOrAlive())
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectSegments(rootState)).toMatchObject(resultSegments);
+  })
+
+  it('should merge segments if possible', () => {
+    initState.segments = [
+      {id: '0', start: 0, end: 5, deleted: false},
+      {id: '0', start: 5, end: 10, deleted: false}
+    ]
+    let resultSegments = [
+      {start: 0, end: 10, deleted: false},
+    ]
+
+    // Act
+    const nextState = reducer(initState, mergeRight())
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectSegments(rootState)).toMatchObject(resultSegments);
+  })
+
+  it('should not merge segments if not possible', () => {
+    initState.activeSegmentIndex = 1
+    initState.segments = [
+      {id: '0', start: 0, end: 5, deleted: false},
+      {id: '0', start: 5, end: 10, deleted: false}
+    ]
+    let resultSegments = [
+      {id: '0', start: 0, end: 5, deleted: false},
+      {id: '0', start: 5, end: 10, deleted: false}
+    ]
+
+    // Act
+    const nextState = reducer(initState, mergeRight())
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectSegments(rootState)).toMatchObject(resultSegments);
+  })
+
+  it('should keep state of active segment when merging', () => {
+    initState.segments = [
+      {id: '0', start: 0, end: 5, deleted: true},
+      {id: '0', start: 5, end: 10, deleted: false}
+    ]
+    let resultSegments = [
+      {start: 0, end: 10, deleted: true},
+    ]
+
+    // Act
+    const nextState = reducer(initState, mergeRight())
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(selectSegments(rootState)).toMatchObject(resultSegments);
+  })
+
+  it('should set loading when fetch is pending', () => {
+    // Arrange
+    const action = { type: fetchVideoInformation.pending.type };
+    const resultStatus: httpRequestState = { status: 'loading', error: undefined }
+
+    // Act
+    const nextState = reducer(initialState, action);
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(rootState.videoState).toMatchObject(resultStatus);
+  })
+
+  it('should set success when fetch is successful', () => {
+    // Arrange
+    const resultStatus: httpRequestState = { status: 'success', error: undefined }
+    const segments = [{ start: 0, end: 42, deleted: false }]
+    const videoURLs: video["videoURLs"] = [ "video/url" ]
+    const dur: video["duration"] = 42
+    const title: video["title"] = "Video Title"
+    // const presenters: video["presenters"] = [ "Otto Opencast" ]    // Currently missing from the API
+    const tracks: video["tracks"] = [{
+      id: "id", uri: videoURLs[0], flavor: { subtype: "prepared", type: "presenter"},
+      videoStream: { available: true, enabled: true, thumbnail_uri: "thumb/url"},
+      audioStream: { available: true, enabled: true}
+    }]
+    const workflows: video["workflows"] = [{ id: "id", name: "Name", displayOrder: 0, description: "Description"}]
+    const action = {
+      type: fetchVideoInformation.fulfilled.type,
+      payload: {
+        duration: dur,
+        title: title,
+        workflows: workflows,
+        tracks: tracks,
+        segments: segments
+      }
+    };
+
+    // Act
+    const nextState = reducer(initialState, action);
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(rootState.videoState).toMatchObject(resultStatus);
+
+    expect(selectSegments(rootState)).toMatchObject(segments);
+    expect(selectVideoURL(rootState)).toMatchObject(videoURLs);
+    expect(selectDuration(rootState)).toEqual(dur);
+    expect(selectTitle(rootState)).toEqual(title);
+    expect(selectPresenters(rootState)).toEqual([]);
+    expect(selectTracks(rootState)).toMatchObject(tracks);
+    expect(selectWorkflows(rootState)).toMatchObject(workflows);
+  })
+
+  it('should set error when fetch is failed', () => {
+    // Arrange
+    const error = { message: "An error message" }
+    const action = { type: fetchVideoInformation.rejected.type, error: error };
+    const resultStatus: httpRequestState = { status: 'failed', error: error.message }
+
+    // Act
+    const nextState = reducer(initialState, action);
+
+    // Assert
+    const rootState = { videoState: nextState };
+    expect(rootState.videoState).toMatchObject(resultStatus);
+  })
+
+  // TODO: Figure out how to properly mock the API and the redux store to test requests
+})

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -25,7 +25,7 @@ export interface video {
   workflows: Workflow[],
 }
 
-const initialState: video & httpRequestState = {
+export const initialState: video & httpRequestState = {
   isPlaying: false,
   isPlayPreview: true,
   currentlyAt: 0,   // Position in the video in milliseconds
@@ -77,14 +77,19 @@ export const videoSlice = createSlice({
     setCurrentlyAt: (state, action: PayloadAction<video["currentlyAt"]>) => {
       state.currentlyAt = roundToDecimalPlace(action.payload, 0);
 
+      if (state.currentlyAt < 0) {
+        state.currentlyAt = 0;
+      }
+
+      if (state.duration !== 0 && state.duration < state.currentlyAt) {
+        state.currentlyAt = state.duration
+      }
+
       updateActiveSegment(state);
       skipDeletedSegments(state);
     },
     setCurrentlyAtInSeconds: (state, action: PayloadAction<video["currentlyAt"]>) => {
-      state.currentlyAt = roundToDecimalPlace(action.payload * 1000, 0);
-
-      updateActiveSegment(state);
-      skipDeletedSegments(state);
+      setCurrentlyAt(roundToDecimalPlace(action.payload * 1000, 0))
     },
     addSegment: (state, action: PayloadAction<video["segments"][0]>) => {
       state.segments.push(action.payload)
@@ -190,7 +195,7 @@ const updateActiveSegment = (state: WritableDraft<video>) => {
 /**
  * Helper Function for testing with current/old editor API
  */
-const parseSegments = (segments: Segment[], duration: number) => {
+export const parseSegments = (segments: Segment[], duration: number) => {
   let newSegments : Segment[] = []
 
   if (segments.length === 0) {


### PR DESCRIPTION
Instead of spouting error messages, `npm test` should now actually run tests. To commemorate this, this PR includes some unit tests for the reducers of `videoSlice`.