### PR TITLE
Limit Repository Sources for Deployment

### DIFF
--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-20.04
+    if: ${{ github.event.pull_request.head.repo.full_name == 'elan-ev/opencast-editor'
+      || github.event.pull_request.head.repo.full_name == 'Arnei/opencast-editor'
+      || github.event.pull_request.head.repo.full_name == 'lkiesow/opencast-editor' }}
     steps:
     - name: generate build path
       run: echo "::set-output name=build::${{github.event.number}}/$(date +%Y-%m-%d_%H-%M-%S)/" | sed 's_build::/*_build::_'


### PR DESCRIPTION
This patch limits the source repositories on which the automated
deployment is run to a few trusted sources. The reason for this is that
running code on `pull_request_target` events allows access to security
tokens which can be extracted if arbitrary code is used.

Limiting the sources should fix the problem since the workflow
configuration is always retrieved from the main repository so that no
one can easily change these filters in a pull request from another
source.