### PR TITLE
Fix Build with no changes

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -62,7 +62,7 @@ jobs:
         cp ~/CNAME .
         cp -r ~/editor-build/* .
         git add ./*
-        git commit -m "Build $(date)"
+        git diff --staged --quiet || git commit -m "Build $(date)"
 
     - name: push updates
       run: |


### PR DESCRIPTION
The build and deployment currently fails if a commit causes no actual
changes to end up in the final build of the editor. This patch fixes the
problem by executing `git commit` only if there are actual changes.

This fixes #25