### PR TITLE
Removed apple-touch-icon from index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,6 @@
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/


### PR DESCRIPTION
Removed a 'link' tag for apple-touch-icons, which we neither have nor could make any use of. Resolves #207