### PR TITLE
Assign Labels to Form Fields

### DIFF
--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -432,6 +432,7 @@ const Metadata: React.FC<{}> = () => {
    * @param input
    */
   const generateComponent = (field: MetadataField, input: any) => {
+    input.id = input.name
     if (field.collection) {
       if (Array.isArray(field.value)) {
         return (
@@ -517,7 +518,7 @@ const Metadata: React.FC<{}> = () => {
                 >
                 {({ input, meta }) => (
                   <div css={fieldStyle}>
-                    <label css={fieldLabelStyle}>{
+                    <label css={fieldLabelStyle} htmlFor={input.name}>{
                       i18n.exists(`metadata.labels.${field.id}`) ?
                       t(`metadata.labels.${field.id}`) : field.id
                     }</label>


### PR DESCRIPTION
This patch actually assigns the existing labels for metadata fields to
the form inputs so that they are related. This is important for
usability (users can now click the label) and accessibility (inputs now
get a proper description).