### PR TITLE
Incorrectly Escaped Start Workflow Text

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -78,7 +78,7 @@
       "saveAndProcess-text": "Save and Process",
       "selectWF-text": "Select a workflow",
       "noWorkflows-text": "A problem occured, there are no workflows to process your changes with.<3/> Please save your changes and contact an Opencast Administrator.\n",
-      "oneWorkflow-text": "The video will be cut and processed with the workflow \\\"{{workflow}}\\\". <3/> This will take some time.\n",
+      "oneWorkflow-text": "The video will be cut and processed with the workflow \"{{workflow}}\". <3/> This will take some time.\n",
       "manyWorkflows-text": "Select which workflow Opencast should use for processing.",
       "startProcessing-button": "Start processing",
       "back-button": "Take me back",


### PR DESCRIPTION
The text describing which workflow will be started unnecessarily escapes
quotation marks twice.