### PR TITLE
Remove Confusing Title Tags

### DIFF
--- a/src/main/Body.tsx
+++ b/src/main/Body.tsx
@@ -20,7 +20,7 @@ const Body: React.FC<{}> = () => {
       );
     } else {
       return (
-        <div css={bodyStyle} title="Body">
+        <div css={bodyStyle}>
           <MainMenu />
           <MainContent />
         </div>

--- a/src/main/MainContent.tsx
+++ b/src/main/MainContent.tsx
@@ -62,7 +62,7 @@ const MainContent: React.FC<{}> = () => {
   })
 
   return (
-     <main title="MainMenuContext" css={{width: '100%'}} role="main">
+     <main css={{width: '100%'}} role="main">
       <div css={cuttingStyle}>
           <Video />
           <CuttingActions />

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -203,7 +203,7 @@ const VideoPlayer: React.FC<{dataKey: number, url: string, isPrimary: boolean}> 
   const render = () => {
     if (!errorState) {
       return(
-        <div css={playerWrapper} title="playerWrapper">
+        <div css={playerWrapper}>
           <ReactPlayer url={url}
             css={reactPlayerStyle}
             ref={ref}


### PR DESCRIPTION
The editor currently contains a lot of non-helpful and often confusing
title tags at what appears to be random HTML elements. This is not
helpful.

This patch removes some, but not all of these.

This is related to #262