### PR TITLE
Remove confusing title tags

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -4,7 +4,6 @@
       "finish-button": "Finish",
       "thumbnail-button": "Thumbnail",
       "metadata-button": "Metadata",
-      "mainMenu-tooltip": "Main Menu",
       "tooltip-aria": "Main Navigation"
     },
 
@@ -36,9 +35,6 @@
       "loadError-text": "An error has occurred loading this video.",
       "title-tooltip": "Video Title",
       "presenter-tooltip": "Video Presenters",
-      "area-tooltip": "Video Area",
-      "area-player-tooltip": "Video Player Area",
-      "area-header-tooltip": "Video Area Header",
       "controls-tooltip": "Video Controls"
     },
 
@@ -89,8 +85,6 @@
     "timeline": {
       "generateWaveform-text": "Generating Waveform",
       "segment-tooltip": "Segment {{segment}}",
-      "scrubber-tooltip": "Scrubber",
-      "dragHandle-tooltip": "dragHandle",
       "scrubber-text-aria": "Scrubber. {{currentTime}}. Active segment: {{segment}}. {{segmentStatus}}. Controls: {{moveLeft}} and {{moveRight}} to move the scrubber. {{increase}} and {{decrease}} to increase/decrase the move delta.\n",
       "segments-text-aria": "Segment {{index}}. {{segmentStatus}}. Start: {{start}}. End: {{end}}.\n"
     },

--- a/src/main/Discard.tsx
+++ b/src/main/Discard.tsx
@@ -35,7 +35,7 @@ const Discard : React.FC<{}> = () => {
   })
 
   return (
-    <div css={cancelStyle} title="Abort Area">
+    <div css={cancelStyle}>
       <h1>{t("discard.headline-text")}</h1>
       <span>
         {t("discard.info-text")}

--- a/src/main/Finish.tsx
+++ b/src/main/Finish.tsx
@@ -37,7 +37,7 @@ const Finish : React.FC<{}> = () => {
   })
 
   return (
-    <div  title="Finish">
+    <div>
       <div css={pageZeroStyle} >
         <FinishMenu />
       </div>

--- a/src/main/FinishMenu.tsx
+++ b/src/main/FinishMenu.tsx
@@ -28,7 +28,7 @@ const FinishMenu : React.FC<{}> = () => {
   })
 
   return (
-    <div css={finishMenuStyle} title="Finish Menu">
+    <div css={finishMenuStyle}>
         <FinishMenuButton iconName={faSave} stateName="Save changes"/>
         <FinishMenuButton iconName={faFileExport} stateName="Start processing"/>
         <FinishMenuButton iconName={faTimesCircle} stateName="Discard changes"/>

--- a/src/main/MainMenu.tsx
+++ b/src/main/MainMenu.tsx
@@ -36,7 +36,7 @@ const MainMenu: React.FC<{}> = () => {
   });
 
   return (
-    <nav css={mainMenuStyle} title={t("mainMenu.mainMenu-tooltip")} role="navigation" aria-label={t("mainMenu.tooltip-aria")}>
+    <nav css={mainMenuStyle} role="navigation" aria-label={t("mainMenu.tooltip-aria")}>
       <MainMenuButton iconName={faFilm} stateName={MainMenuStateNames.cutting}/>
       {settings.metadata.show && <MainMenuButton iconName={faListUl} stateName={MainMenuStateNames.metadata}/>}
       {settings.thumbnail.show && <MainMenuButton iconName={faPhotoVideo} stateName={MainMenuStateNames.thumbnail}/>}

--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -570,7 +570,7 @@ const Metadata: React.FC<{}> = () => {
               form.reset()
             }} css={metadataStyle}>
 
-              <div css={errorBoxStyle(getStatus === "failed")} title="Error Box" role="alert">
+              <div css={errorBoxStyle(getStatus === "failed")} role="alert">
                 <span>A problem occurred during communication with Opencast.</span><br />
                 {getError ? "Details: " + getError : "No error details are available."}<br />
               </div>
@@ -601,7 +601,7 @@ const Metadata: React.FC<{}> = () => {
                 </button>
               </div> */}
 
-              <div css={errorBoxStyle(postStatus === "failed")} title="Error Box" role="alert">
+              <div css={errorBoxStyle(postStatus === "failed")} role="alert">
                 <span>A problem occurred during communication with Opencast. <br />
                       Changes could not be saved to Opencast.</span><br />
                 {postError ? "Details: " + postError : "No error details are available."}<br />

--- a/src/main/Save.tsx
+++ b/src/main/Save.tsx
@@ -53,11 +53,11 @@ const Save : React.FC<{}> = () => {
         <PageButton pageNumber={0} label={t("various.goBack-button")} iconName={faChevronLeft}/>
         <SaveButton />
       </div>
-      <div css={errorBoxStyle(postWorkflowStatus === "failed")} title="Error Box" role="alert">
+      <div css={errorBoxStyle(postWorkflowStatus === "failed")} role="alert">
         <span>{t("various.error-text")}</span><br />
         {postError ? t("various.error-details-text", {errorMessage: postError}) : t("various.error-noDetails-text")}<br />
       </div>
-      <div css={errorBoxStyle(postMetadataStatus === "failed")} title="Error Box" role="alert">
+      <div css={errorBoxStyle(postMetadataStatus === "failed")} role="alert">
         <span>{t("various.error-text")}</span><br />
         {postMetadataError ? t("various.error-details-text", {errorMessage: postMetadataError}) : t("various.error-noDetails-text")}<br />
       </div>

--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -219,10 +219,10 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
         position={controlledPosition}
         nodeRef={nodeRef}
         >
-          <div ref={nodeRef} css={scrubberStyle} title={t("timeline.scrubber-tooltip")}>
+          <div ref={nodeRef} css={scrubberStyle}>
 
             <div css={arrowDownStyle}></div>
-            <div css= {scrubberDragHandleStyle} title={t("timeline.dragHandle-tooltip")} aria-grabbed={isGrabbed}
+            <div css= {scrubberDragHandleStyle} aria-grabbed={isGrabbed}
               aria-label={t("timeline.scrubber-text-aria",
                          {currentTime: convertMsToReadableString(currentlyAt), segment: activeSegmentIndex,
                           segmentStatus: (segments[activeSegmentIndex].deleted ? "Deleted" : "Alive"),

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -67,7 +67,7 @@ const Video: React.FC<{}> = () => {
 
   const errorBox = () => {
     return (
-      <div css={errorBoxStyle(videoURLStatus === "failed")} title="Error Box" role="alert">
+      <div css={errorBoxStyle(videoURLStatus === "failed")} role="alert">
         <span>{t("video.comError-text")}</span><br />
         {error ? t("various.error-details-text", {errorMessage: error}) : t("various.error-noDetails-text")}<br />
       </div>
@@ -94,10 +94,10 @@ const Video: React.FC<{}> = () => {
   });
 
   return (
-    <div css={videoAreaStyle} title={t("video.area-tooltip")}>
+    <div css={videoAreaStyle}>
       {errorBox()}
       <VideoHeader />
-      <div css={videoPlayerAreaStyle} title={t("video.area-player-tooltip")}>
+      <div css={videoPlayerAreaStyle}>
         {videoPlayers}
       </div>
       <VideoControls />
@@ -224,7 +224,7 @@ const VideoPlayer: React.FC<{dataKey: number, url: string, isPrimary: boolean}> 
       );
     } else {
       return (
-        <div css={errorBoxStyle} title="Error Box" role="alert">
+        <div css={errorBoxStyle} role="alert">
           <span>{t("video.loadError-text")} </span>
         </div>
       );

--- a/src/main/WorkflowConfiguration.tsx
+++ b/src/main/WorkflowConfiguration.tsx
@@ -48,11 +48,11 @@ const WorkflowConfiguration : React.FC<{}> = () => {
         <PageButton pageNumber={1} label={t("various.goBack-button")} iconName={faChevronLeft}/>
         <SaveAndProcessButton text={t("workflowConfig.confirm-button")}/>
       </div>
-      <div css={errorBoxStyle(postAndProcessWorkflowStatus === "failed")} title="Error Box" role="alert">
+      <div css={errorBoxStyle(postAndProcessWorkflowStatus === "failed")} role="alert">
         <span>{t("various.error-text")}</span><br />
         {postAndProcessError ? t("various.error-details-text", {errorMessage: postAndProcessError}) : t("various.error-noDetails-text")}<br/>
       </div>
-      <div css={errorBoxStyle(postMetadataStatus === "failed")} title="Error Box" role="alert">
+      <div css={errorBoxStyle(postMetadataStatus === "failed")} role="alert">
         <span>{t("various.error-text")}</span><br />
         {postMetadataError ? t("various.error-details-text", {errorMessage: postMetadataError}) : t("various.error-noDetails-text")}<br />
       </div>

--- a/src/main/WorkflowSelection.tsx
+++ b/src/main/WorkflowSelection.tsx
@@ -95,7 +95,7 @@ const WorkflowSelection : React.FC<{}> = () => {
           {/* <PageButton pageNumber={2} label="Continue" iconName={faChevronRight}/> */}
           {nextButton}
         </div>
-        <div css={errorBoxStyle(errorStatus === "failed")} title="Error Box" role="alert">
+        <div css={errorBoxStyle(errorStatus === "failed")} role="alert">
           <span>{t("various.error-text")}</span><br />
           {errorMessage ? t("various.error-details-text", {errorMessage: postAndProcessError}) : t("various.error-noDetails-text")}<br/>
         </div>


### PR DESCRIPTION
This patch removes a number of confusing and in some cases even more
harmful than helpful title tags from the editor.

![Screenshot from 2021-05-19 00-06-44](https://user-images.githubusercontent.com/1008395/118729590-7a07ac00-b836-11eb-8ddf-7f07045344ac.png)
