### PR TITLE
Rework scrubber hotkeys arrows

### DIFF
--- a/src/globalKeys.ts
+++ b/src/globalKeys.ts
@@ -17,11 +17,11 @@ export const cuttingKeyMap: KeyMap = {
 }
 
 /**
- * Local map for moving the scrubber
+ * (Semi-) global map for moving the scrubber
  */
 export const scrubberKeyMap: KeyMap = {
-  left: "Control+Alt+j",
-  right: "Control+Alt+l",
-  increase: "Control+Alt+i",
-  decrease: "Control+Alt+k",
+  left: ["Control+Alt+j", "ArrowLeft"],
+  right: ["Control+Alt+l", "ArrowRight"],
+  increase: ["Control+Alt+i", "ArrowUp"],
+  decrease: ["Control+Alt+k", "ArrowDown"],
 }

--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -5,7 +5,7 @@ import Draggable from 'react-draggable';
 import { css } from '@emotion/react'
 
 import { useSelector, useDispatch } from 'react-redux';
-import { Segment, httpRequestState } from '../types'
+import { Segment, httpRequestState, MainMenuStateNames } from '../types'
 import {
   selectIsPlaying, selectCurrentlyAt, selectSegments, selectActiveSegmentIndex, selectDuration,
   setIsPlaying, selectVideoURL, setCurrentlyAt, setClickTriggered
@@ -18,11 +18,12 @@ import useResizeObserver from "use-resize-observer";
 
 import { Waveform } from '../util/waveform'
 import { convertMsToReadableString } from '../util/utilityFunctions';
-import { HotKeys } from 'react-hotkeys';
+import { GlobalHotKeys } from 'react-hotkeys';
 import { scrubberKeyMap } from '../globalKeys';
 
 import './../i18n/config';
 import { useTranslation } from 'react-i18next';
+import { selectMainMenuState } from '../redux/mainMenuSlice';
 
 /**
  * A container for visualizing the cutting of the video, as well as for controlling
@@ -78,6 +79,7 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
   const duration = useSelector(selectDuration)
   const activeSegmentIndex = useSelector(selectActiveSegmentIndex)  // For ARIA information display
   const segments = useSelector(selectSegments)                      // For ARIA information display
+  const mainMenuState = useSelector(selectMainMenuState)            // For hotkey enabling/disabling
 
   // Init state variables
   const [controlledPosition, setControlledPosition] = useState({x: 0,y: 0,});
@@ -209,7 +211,7 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
   // }
 
   return (
-    <HotKeys keyMap={scrubberKeyMap} handlers={handlers} allowChanges={true}>
+    <GlobalHotKeys keyMap={scrubberKeyMap} handlers={mainMenuState === MainMenuStateNames.cutting ? handlers: {}} allowChanges={true}>
       <Draggable
         //onDrag={onControlledDrag}
         onStart={onStartDrag}
@@ -237,7 +239,7 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
             <div css={arrowUpStyle}></div>
           </div>
       </Draggable>
-    </HotKeys>
+    </GlobalHotKeys>
   );
 };
 


### PR DESCRIPTION
Allows the scrubber to be moved by the arrow keys in addition to the already defined hotkeys. 

This PR still keeps the already defined hotkeys (Ctrl+Alt+J etc.) as the default hotkeys, since the arrow key behaviour is overriden by the orca screenreader when using it. Preferably this PR is tested with other screenreaders as well.

Contains #305, so that one should be merged first.

Resolves #300.