### PR TITLE
Added error page

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -161,6 +161,11 @@
       }
     },
 
+    "error": {
+      "generic-message": "A critical error has occurred!",
+      "details": "Details: "
+    },
+
     "various": {
       "error-details-text": "Details: {{errorMessage}}\n",
       "error-noDetails-text": "No error details are available.",

--- a/src/main/Body.tsx
+++ b/src/main/Body.tsx
@@ -3,20 +3,27 @@ import React from "react";
 import MainMenu from './MainMenu';
 import MainContent from './MainContent';
 import TheEnd from './TheEnd';
+import Error from './Error';
 
 import { useSelector } from 'react-redux';
 import { selectIsEnd } from '../redux/endSlice'
+import { selectIsError } from "../redux/errorSlice";
 
 const Body: React.FC<{}> = () => {
 
   const isEnd = useSelector(selectIsEnd)
+  const isError = useSelector(selectIsError)
 
   // If we're in a special state, display a special page
   // Otherwise display the normal page
   const main = () => {
-    if(isEnd) {
+    if (isEnd) {
       return (
         <TheEnd />
+      );
+    } else if (isError) {
+      return (
+        <Error />
       );
     } else {
       return (

--- a/src/main/Error.tsx
+++ b/src/main/Error.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+
+import { css } from '@emotion/react'
+
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faFrown } from "@fortawesome/free-solid-svg-icons";
+
+import { useSelector } from 'react-redux';
+import { selectErrorDetails, selectErrorMessage } from '../redux/errorSlice'
+import { flexGapReplacementStyle } from "../cssStyles";
+
+import './../i18n/config';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * This page is to be displayed when the application has run into a critical error
+ * from which it cannot recover.
+ */
+ const Error : React.FC<{}> = () => {
+
+  const { t } = useTranslation();
+
+  // Init redux variables
+  const errorMessage = useSelector(selectErrorMessage)
+  const errorDetails = useSelector(selectErrorDetails)
+
+  const theEndStyle = css({
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: '20px',
+    lineHeight: '0.2',
+    ...(flexGapReplacementStyle(20, false)),
+  })
+
+  return (
+    <div css={theEndStyle} >
+      <div>{t("error.generic-message")}</div>
+      <FontAwesomeIcon icon={faFrown} size="10x" />
+      <span>{errorMessage}</span><br />
+      <span>{t("error.details")}</span><br />
+      {errorDetails ? errorDetails : t("various.error-noDetails-text") }
+    </div>
+  );
+}
+
+export default Error

--- a/src/main/Error.tsx
+++ b/src/main/Error.tsx
@@ -24,16 +24,19 @@ import { useTranslation } from 'react-i18next';
   const errorMessage = useSelector(selectErrorMessage)
   const errorDetails = useSelector(selectErrorDetails)
 
+  const detailsStyle = css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  })
+
   const theEndStyle = css({
-    width: '100%',
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    padding: '20px',
-    lineHeight: '0.2',
-    ...(flexGapReplacementStyle(20, false)),
+    ...(flexGapReplacementStyle(10, false)),
   })
 
   return (
@@ -41,8 +44,10 @@ import { useTranslation } from 'react-i18next';
       <div>{t("error.generic-message")}</div>
       <FontAwesomeIcon icon={faFrown} size="10x" />
       <span>{errorMessage}</span><br />
-      <span>{t("error.details")}</span><br />
-      {errorDetails ? errorDetails : t("various.error-noDetails-text") }
+      <div css={detailsStyle}>
+        <span>{t("error.details")}</span><br />
+        <span>{errorDetails ? errorDetails : t("various.error-noDetails-text") }</span>
+      </div>
     </div>
   );
 }

--- a/src/main/Video.tsx
+++ b/src/main/Video.tsx
@@ -17,7 +17,7 @@ import {
 import ReactPlayer, { Config } from 'react-player'
 
 import { roundToDecimalPlace, convertMsToReadableString } from '../util/utilityFunctions'
-import { errorBoxStyle, basicButtonStyle, flexGapReplacementStyle } from "../cssStyles";
+import { basicButtonStyle, flexGapReplacementStyle } from "../cssStyles";
 
 import { GlobalHotKeys } from 'react-hotkeys';
 import { selectMainMenuState } from "../redux/mainMenuSlice";
@@ -25,6 +25,7 @@ import { cuttingKeyMap } from "../globalKeys";
 import { SyntheticEvent } from "react";
 import './../i18n/config';
 import { useTranslation } from 'react-i18next';
+import { setError } from "../redux/errorSlice";
 
 /**
  * Container for the videos and their controls
@@ -44,9 +45,11 @@ const Video: React.FC<{}> = () => {
   // Try to fetch URL from external API
   useEffect(() => {
     if (videoURLStatus === 'idle') {
-        dispatch(fetchVideoInformation())
+      dispatch(fetchVideoInformation())
+    } else if (videoURLStatus === 'failed') {
+      dispatch(setError({error: true, errorMessage: t("video.comError-text"), errorDetails: error}))
     }
-  }, [videoURLStatus, dispatch])
+  }, [videoURLStatus, dispatch, error, t])
 
   // Update based on current fetching status
   // let content
@@ -63,15 +66,6 @@ const Video: React.FC<{}> = () => {
   for (let i = 0; i < videoCount; i++) {
     // videoPlayers.push(<VideoPlayer key={i} url='https://media.geeksforgeeks.org/wp-content/uploads/20190616234019/Canvas.move_.mp4' />);
     videoPlayers.push(<VideoPlayer key={i} dataKey={i} url={videoURLs[i]} isPrimary={i === 0}/>);
-  }
-
-  const errorBox = () => {
-    return (
-      <div css={errorBoxStyle(videoURLStatus === "failed")} role="alert">
-        <span>{t("video.comError-text")}</span><br />
-        {error ? t("various.error-details-text", {errorMessage: error}) : t("various.error-noDetails-text")}<br />
-      </div>
-    );
   }
 
   // Style
@@ -95,7 +89,6 @@ const Video: React.FC<{}> = () => {
 
   return (
     <div css={videoAreaStyle}>
-      {errorBox()}
       <VideoHeader />
       <div css={videoPlayerAreaStyle}>
         {videoPlayers}

--- a/src/redux/errorSlice.ts
+++ b/src/redux/errorSlice.ts
@@ -1,0 +1,41 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+interface error {
+  error: boolean,
+  errorMessage: string,
+  errorDetails: string | undefined,
+}
+
+const initialState: error = {
+  error: false,
+  errorMessage: "Unknown error",
+  errorDetails: "",
+}
+
+/**
+ * Slice for the error page state
+ */
+export const errorSlice = createSlice({
+  name: 'errorState',
+  initialState,
+  reducers: {
+    setError: (state, action: PayloadAction<{
+      error: error["error"],
+      errorMessage: error["errorMessage"],
+      errorDetails: error["errorDetails"]
+    }>) => {
+      state.error = action.payload.error;
+      state.errorMessage = action.payload.errorMessage;
+      state.errorDetails = action.payload.errorDetails;
+    },
+  }
+})
+
+export const { setError, } = errorSlice.actions
+
+// Export Selectors
+export const selectIsError = (state: { errorState: { error: error["error"] }; }) => state.errorState.error
+export const selectErrorMessage = (state: { errorState: { errorMessage: error["errorMessage"] }; }) => state.errorState.errorMessage
+export const selectErrorDetails = (state: { errorState: { errorDetails: error["errorDetails"] }; }) => state.errorState.errorDetails
+
+export default errorSlice.reducer

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -6,6 +6,7 @@ import workflowPostReducer from './workflowPostSlice'
 import workflowPostAndProcessReducer from './workflowPostAndProcessSlice'
 import endReducer from './endSlice'
 import metadataReducer from './metadataSlice'
+import errorReducer from './errorSlice'
 
 export default configureStore({
   reducer: {
@@ -16,5 +17,6 @@ export default configureStore({
     workflowPostAndProcessState: workflowPostAndProcessReducer,
     endState: endReducer,
     metadataState: metadataReducer,
+    errorState: errorReducer,
   }
 })

--- a/src/util/client.js
+++ b/src/util/client.js
@@ -34,8 +34,9 @@ export async function client(endpoint, { body, ...customConfig } = {}) {
 
   let data
   let text
+  let response
   try {
-    const response = await window.fetch(endpoint, config)
+    response = await window.fetch(endpoint, config)
     text = await response.text()
 
     if (response.url.includes("login.html")) {
@@ -48,7 +49,10 @@ export async function client(endpoint, { body, ...customConfig } = {}) {
     }
     throw new Error(response.statusText)
   } catch (err) {
-    return Promise.reject(err.message ? err.message : data)
+    return Promise.reject(response.status ?
+        "Status " + response.status + ": " + text :
+        err.message
+      )
   }
 }
 


### PR DESCRIPTION
Introduces an error page that can be displayed in case of an unrecoverable error.
Failures that occur when fetching information for Opencast will now cause the error page to appear.

Can be tested by calling the editor with a non-existant mediaPackageId, for example `?mediaPackageId=nonsense`.

Partially resolves #162 (Error page is not yet shown if the media package exists but the contents are faulty).