### PR TITLE
Added a validator for datetime metadata fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11764,9 +11764,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mui-rff": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/mui-rff/-/mui-rff-3.0.6.tgz",
-      "integrity": "sha512-SzRrYKbfiMXLXGO4AU2YTWWnStqZP4tFEBT3zAOndvjp+CgnmAjg98NGY2agkG0uhbbDnPRFqXl6JpyUKhoPfg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/mui-rff/-/mui-rff-3.0.7.tgz",
+      "integrity": "sha512-mrIJVcprEIN2PAYBPG2tYGsR5gRn1Tsmq5U7U+JZqfNVUKWUaqTCGpmwB28tajq1o5hvsBIISmcDlvP3qvo6Bg==",
       "requires": {
         "@date-io/core": "^1.3.13",
         "@date-io/date-fns": "^1.3.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3578,6 +3578,12 @@
       "integrity": "sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==",
       "dev": true
     },
+    "@types/luxon": {
+      "version": "1.26.5",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-1.26.5.tgz",
+      "integrity": "sha512-XeQxxRMyJi1znfzHw4CGDLyup/raj84SnjjkI2fDootZPGlB0yqtvlvEIAmzHDa5wiEI5JJevZOWxpcofsaV+A==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -11388,6 +11394,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.27.0.tgz",
+      "integrity": "sha512-VKsFsPggTA0DvnxtJdiExAucKdAnwbCCNlMM5ENvHlxubqWd0xhZcdb4XgZ7QFNhaRhilXCFxHuoObP5BNA4PA=="
     },
     "lz-string": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "i18next": "^20.2.2",
     "i18next-browser-languagedetector": "^6.1.0",
     "lodash.clonedeep": "^4.5.0",
+    "luxon": "^1.27.0",
     "mui-rff": "^3.0.6",
     "react": "^17.0.2",
     "react-app-rewired": "^2.1.8",
@@ -79,6 +80,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.168",
+    "@types/luxon": "^1.26.5",
     "@types/react-select": "^4.0.15",
     "redux-devtools": "^3.7.0",
     "use-resize-observer": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "i18next-browser-languagedetector": "^6.1.0",
     "lodash.clonedeep": "^4.5.0",
     "luxon": "^1.27.0",
-    "mui-rff": "^3.0.6",
+    "mui-rff": "^3.0.7",
     "react": "^17.0.2",
     "react-app-rewired": "^2.1.8",
     "react-dom": "^17.0.2",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -105,7 +105,8 @@
       "submit-helpertext": "Make changes as you like, then hit the {{buttonName}} button.\nNote that you will still have to start processing for your changes to take effect.",
       "validation": {
         "required": "Required",
-        "duration-format": "Format must be HH:MM:SS"
+        "duration-format": "Format must be HH:MM:SS",
+        "datetime": "Invalid"
       },
       "labels": {
         "title": "Title",

--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -24,6 +24,7 @@ import './../i18n/config';
 import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { DateTime as LuxonDateTime} from "luxon";
 
 /**
  * Creates a Metadata form
@@ -249,6 +250,25 @@ const Metadata: React.FC<{}> = () => {
     return re.test(value) ? undefined : t("metadata.validation.duration-format")
   }
 
+  /**
+   * Validator for the date time fields
+   * @param date
+   */
+  const dateTimeValidator = (date: any) => {
+    let dt = undefined
+    if (Object.prototype.toString.call(date) === '[object Date]') {
+      dt = LuxonDateTime.fromJSDate(date);
+    }
+    if (typeof(date) === 'string') {
+      dt = LuxonDateTime.fromISO(date);
+    }
+
+    if (dt) {
+      return dt.isValid ? "" : "Invalid"
+    }
+    return "Invalid"
+  }
+
   // // Function that combines multiple validation functions. Needs to be made typescript conform
   // const composeValidators = (...validators) => value =>
   // validators.reduce((error, validator) => error || validator(value), undefined)
@@ -263,6 +283,8 @@ const Metadata: React.FC<{}> = () => {
       return required
     } else if (field.id === "duration") {
       return duration
+    } else if (field.type === "date" || field.type === "time") {
+      return dateTimeValidator
     } else {
       return undefined
     }

--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -269,9 +269,9 @@ const Metadata: React.FC<{}> = () => {
     }
 
     if (dt) {
-      return dt.isValid ? undefined : "Invalid"
+      return dt.isValid ? undefined : t("metadata.validation.datetime")
     }
-    return "Invalid"
+    return t("metadata.validation.datetime")
   }
 
   // // Function that combines multiple validation functions. Needs to be made typescript conform

--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -256,7 +256,7 @@ const Metadata: React.FC<{}> = () => {
    */
   const dateTimeValidator = (date: any) => {
     // Empty field is valid value in Opencast
-    if (!date) {
+    if (date === "") {
       return undefined
     }
 
@@ -371,7 +371,9 @@ const Metadata: React.FC<{}> = () => {
     if (field && (field.type === "date" || field.type === "time") && Object.prototype.toString.call(returnValue) === '[object Date]') {
       returnValue = returnValue.toJSON()
     } else if (field && (field.type === "date" || field.type === "time") && typeof returnValue === "string") {
-      returnValue = new Date(returnValue).toJSON()
+      if (returnValue !== "") { // Empty string is allowed
+        returnValue = new Date(returnValue).toJSON()
+      }
     }
 
     return returnValue

--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -255,6 +255,11 @@ const Metadata: React.FC<{}> = () => {
    * @param date
    */
   const dateTimeValidator = (date: any) => {
+    // Empty field is valid value in Opencast
+    if (!date) {
+      return undefined
+    }
+
     let dt = undefined
     if (Object.prototype.toString.call(date) === '[object Date]') {
       dt = LuxonDateTime.fromJSDate(date);
@@ -264,7 +269,7 @@ const Metadata: React.FC<{}> = () => {
     }
 
     if (dt) {
-      return dt.isValid ? "" : "Invalid"
+      return dt.isValid ? undefined : "Invalid"
     }
     return "Invalid"
   }


### PR DESCRIPTION
For whatever reason, `mui-rff` disables the automatic datetime validation from material-ui, so we have to do the validation ourselves.

Resolves #297