### PR TITLE
Change scrubber handle design

### DIFF
--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -155,7 +155,7 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
 
   const scrubberStyle = css({
     backgroundColor: 'black',
-    height: '250px',
+    height: '240px',
     width: '1px',
     position: 'absolute' as 'absolute',
     zIndex: 2,
@@ -167,13 +167,24 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
   });
 
   const scrubberDragHandleStyle = css({
-    backgroundColor: 'rgba(255, 255, 255, 1)',
-    borderRadius: '10px',
-    height: '50px',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    boxShadow: '0 0 10px rgba(0, 0, 0, 0.3)',
+    // Base style
+    background: "black",
+    display: "inline-block",
+    height: "10px",
+    position: "relative",
+    width: "20px",
+    "&:after": {
+      borderTop: '10px solid black',
+      borderLeft: '10px solid transparent',
+      borderRight: '10px solid transparent',
+      content: '""',
+      height: 0,
+      left: 0,
+      position: "absolute",
+      top: "10px",
+      width: 0,
+    },
+    // Animation
     cursor: isGrabbed ? "grabbing" : "grab",
     transitionDuration: "0.3s",
     transitionProperty: "transform",
@@ -186,24 +197,9 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
   })
 
   const scrubberDragHandleIconStyle = css({
-    transform: 'scaleY(1.5) rotate(90deg)',
-    padding: '5px',
-  })
-
-  const arrowUpStyle = css({
-    width: 0,
-    height: 0,
-    borderLeft: '7px solid transparent',
-    borderRight: '7px solid transparent',
-    borderBottom: '7px solid black',
-  })
-
-  const arrowDownStyle = css({
-    width: 0,
-    height: 0,
-    borderLeft: '7px solid transparent',
-    borderRight: '7px solid transparent',
-    borderTop: '7px solid black',
+    transform: 'scaleY(0.7) rotate(90deg)',
+    paddingRight: '5px',
+    color: "white"
   })
 
   // // Possible TODO: Find a way to use ariaLive in a way that only the latest change is announced
@@ -224,8 +220,7 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
         >
           <div ref={nodeRef} css={scrubberStyle}>
 
-            <div css={arrowDownStyle}></div>
-            <div css= {scrubberDragHandleStyle} aria-grabbed={isGrabbed}
+            <div css={scrubberDragHandleStyle} aria-grabbed={isGrabbed}
               aria-label={t("timeline.scrubber-text-aria",
                          {currentTime: convertMsToReadableString(currentlyAt), segment: activeSegmentIndex,
                           segmentStatus: (segments[activeSegmentIndex].deleted ? "Deleted" : "Alive"),
@@ -235,9 +230,7 @@ const Scrubber: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
                           decrease: scrubberKeyMap[handlers.decrease.name] })}
               tabIndex={0}>
               <FontAwesomeIcon css={scrubberDragHandleIconStyle} icon={faBars} size="1x" />
-              {/* <div css={ariaLive} aria-live="polite" aria-atomic="true">{keyboardUpdateMessage()}</div> */}
             </div>
-            <div css={arrowUpStyle}></div>
           </div>
       </Draggable>
     </GlobalHotKeys>


### PR DESCRIPTION
Moves the scrubber head to the top of the timeline, to make the waveform more visible.
Also changes the design to be more in line with traditional video editors.

Resolves  #153