### PR TITLE
Added a config option for displaying metadata fields

### DIFF
--- a/public/editor-settings.toml
+++ b/public/editor-settings.toml
@@ -20,6 +20,23 @@ password = "opencast"
 [metadata]
 # If false, the metadata button is not displayed in the main menu
 show = true
+## Configure metadata display
+## Here you can set which metadata fields should be displayed in the editor
+## for each catalog.
+## If the catalog is not specified, all fields of that catalog will be
+## displayed.
+## If the catalog is specified but empty, it will not be displayed at all.
+## If the catalog is specified with at least one field, only the fields
+## specified for the catalog will be displayed.
+[metadata.showFields]
+## Example definition
+# # This is the default catalog
+# "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE" = [
+#   "title",
+#   "language",
+#   "duration"
+# ]
+# "NameOfAnExtendedMetadataCatalog" = []
 
 ### Settings of the thumbnail tab
 [thumbnail]

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,7 @@ interface iSettings {
   },
   metadata: {
     show: boolean,
+    showFields: { [key: string]: string[]; } | undefined,
   },
   thumbnail: {
     show: boolean,
@@ -51,6 +52,7 @@ var defaultSettings: iSettings = {
   },
   metadata: {
     show: true,
+    showFields: undefined,
   },
   thumbnail: {
     show: true,
@@ -235,6 +237,21 @@ const types = {
       throw new Error("is not a boolean");
     }
   },
+  'objectWithStringArrays': (v: any, allowParse: any) => {
+    for (let key in v) {
+      if (typeof key !== 'string') {
+        throw new Error("is not a string, but should be");
+      }
+      if (!Array.isArray(v[key])) {
+        throw new Error("is not an array, but should be");
+      }
+      for (let item in v[key]) {
+        if (typeof item !== 'string') {
+          throw new Error("is not a string, but should be");
+        }
+      }
+    }
+  }
 };
 
 // Defines all potential settings and their types.
@@ -256,6 +273,7 @@ const SCHEMA = {
   },
   metadata: {
     show : types.boolean,
+    showFields: types.objectWithStringArrays,
   },
   thumbnail: {
     show : types.boolean,

--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -25,6 +25,9 @@ import { useTranslation } from 'react-i18next';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck } from "@fortawesome/free-solid-svg-icons";
 
+import { settings } from '../config'
+
+
 /**
  * Creates a Metadata form
  *
@@ -536,8 +539,9 @@ const Metadata: React.FC<{}> = () => {
    * Renders a single catalog (e.g. dublincore/episode) in the form
    * @param catalog
    * @param catalogIndex
+   * @param showFields array of which fields should be displayed. If empty, display all
    */
-  const renderCatalog = (catalog: Catalog, catalogIndex: number) => {
+  const renderCatalog = (catalog: Catalog, catalogIndex: number, showFields: string[]) => {
     return (
       <div key={catalogIndex}>
         <h2>
@@ -547,6 +551,15 @@ const Metadata: React.FC<{}> = () => {
         </h2>
 
         {catalog.fields.map((field, i) => {
+          // Render fields based on given array (usually parsed from config settings)
+          if (showFields.length !== 0) {
+            // Lowercase include
+            if (showFields.filter((str) => str.toLowerCase().includes(field.id.toLowerCase())).length > 0) {
+              return renderField(field, catalogIndex, i)
+            } else {
+              return undefined
+            }
+          }
           return renderField(field, catalogIndex, i)
         })}
 
@@ -576,7 +589,19 @@ const Metadata: React.FC<{}> = () => {
               </div>
 
               {catalogs.map((catalog, i) => {
-                return renderCatalog(catalog, i)
+                // Render catalog and its fields based on config settings
+                if (settings.metadata.showFields) {
+                  if (catalog.title in settings.metadata.showFields) {
+                    // If there are no fields for a given catalog, do not render it
+                    if (settings.metadata.showFields[catalog.title].length > 0) {
+                      return renderCatalog(catalog, i, settings.metadata.showFields[catalog.title])
+                    } else {
+                      return undefined
+                    }
+                  }
+                }
+                // If there are no settings for a given catalog, just render it completely
+                return renderCatalog(catalog, i, [])
               })}
 
 {/* 


### PR DESCRIPTION
Added an option to the editor-settings that lets users control which metadata catalogs and fields are displayed in the editor.

Resolves #38. Does not resolve the follow up request regarding read-only configuration in the same issue.