### PR TITLE
Removed scroll bars from TheEnd

### DIFF
--- a/src/main/TheEnd.tsx
+++ b/src/main/TheEnd.tsx
@@ -49,7 +49,6 @@ const TheEnd : React.FC<{}> = () => {
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',
-    padding: '20px',
     ...(flexGapReplacementStyle(20, false)),
   })
 


### PR DESCRIPTION
After clicking on "start processing" or "discard changes", the final page that is shown has scroll bars for no reason. These are now removed.