### PR TITLE
Fixed preview mode playback not jumping to next non-deleted segment

### DIFF
--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -242,13 +242,20 @@ const mergeSegments = (state: WritableDraft<video>, activeSegmentIndex: number, 
 const skipDeletedSegments = (state: WritableDraft<video>) => {
   if(state.isPlaying && state.segments[state.activeSegmentIndex].deleted && state.isPlayPreview) {
       let endTime = state.segments[state.activeSegmentIndex].end
-      let index = state.activeSegmentIndex
-      while (index < state.segments.length && state.segments[index].deleted) {
+
+      for (let index = state.activeSegmentIndex; index < state.segments.length; index++) {
         endTime = state.segments[index].end
-        index++
+
+        if (!state.segments[index].deleted) {
+          // Need to at +1 as start and end of neighbouring segments are identical
+          endTime = state.segments[index].start + 1
+          break
+        }
       }
+
       state.currentlyAt = endTime
       state.previewTriggered = true
+      updateActiveSegment(state);
     }
 }
 


### PR DESCRIPTION
When skipping deleted segments during preview mode playback, the skip ended up at the end of the deleted segment, not the start of the next non-deleted segment, causing weird visual flickering for a brief moment. This fixes that.

Partially resolves #198. I would prefer discussing the issue of whether the cutting action buttons should be disabled during (preview) separately from this.