### PR TITLE
Added landing page

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -166,6 +166,14 @@
       "details": "Details: "
     },
 
+    "landing": {
+      "main-heading": "Welcome to the Video Editor",
+      "contact-admin": "If you were trying to edit a specific video but are seeing this page, please contact your administrator.",
+      "start-editing-1": "To start editing, specify the parameter ",
+      "start-editing-2": " with the media package id of the video you wish to edit.",
+      "link-to-documentation": "More information about configuring the video editor is available in the administration guide at "
+    },
+
     "various": {
       "error-details-text": "Details: {{errorMessage}}\n",
       "error-noDetails-text": "No error details are available.",

--- a/src/main/Body.tsx
+++ b/src/main/Body.tsx
@@ -4,10 +4,13 @@ import MainMenu from './MainMenu';
 import MainContent from './MainContent';
 import TheEnd from './TheEnd';
 import Error from './Error';
+import Landing from "./Landing";
 
 import { useSelector } from 'react-redux';
 import { selectIsEnd } from '../redux/endSlice'
 import { selectIsError } from "../redux/errorSlice";
+import { settings } from '../config';
+
 
 const Body: React.FC<{}> = () => {
 
@@ -17,7 +20,11 @@ const Body: React.FC<{}> = () => {
   // If we're in a special state, display a special page
   // Otherwise display the normal page
   const main = () => {
-    if (isEnd) {
+    if (!settings.mediaPackageId) {
+      return (
+        <Landing />
+      )
+    } else if (isEnd) {
       return (
         <TheEnd />
       );

--- a/src/main/Landing.tsx
+++ b/src/main/Landing.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+
+import { css } from '@emotion/react'
+
+import './../i18n/config';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * This page is to be displayed when the application has run into a critical error
+ * from which it cannot recover.
+ */
+ const Landing : React.FC<{}> = () => {
+
+  const { t } = useTranslation();
+
+  const landingStyle = css({
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+
+    a: {
+      color: '#007bff',
+      textDecoration: 'none',
+    },
+    li: {
+      margin: '5px',
+    },
+    code: {
+      userSelect: 'all',
+      color: '#e83e8c',
+    }
+  })
+
+  return (
+    <div css={landingStyle} >
+      <h1>{t("landing.main-heading")}</h1>
+      <div>
+        <li>
+        {t("landing.contact-admin")}
+        </li>
+        <li>
+          {t("landing.start-editing-1")}
+          <code> ?=mediaPackageId=[media-package-id]</code>
+          {t("landing.start-editing-2")}
+        </li>
+        <li>
+          {t("landing.link-to-documentation")}
+          <a href="https://docs.opencast.org/stable/admin/">docs.opencast.org</a>
+        </li>
+      </div>
+    </div>
+  );
+}
+
+export default Landing


### PR DESCRIPTION
The editor relies on a mediapackage ID to function properly. Instead of showing an error when it is missing, this instead displays a landing page with various information.

To test this, remove the field `mediaPackageId` from `public/editor-settings.toml` and call the editor without the parameter `
?mediaPackageId=[id]`.

Resolves #163.

![Bildschirmfoto vom 2021-05-28 13-49-43](https://user-images.githubusercontent.com/14070005/119979679-92589300-bfbb-11eb-9ed9-7175ef836792.png)