### PR TITLE
Fixed waveform generation always throwing error

### DIFF
--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -362,7 +362,7 @@ const Waveforms: React.FC<{}> = () => {
           // Start waveform worker with blob
           const waveformWorker : any = new Waveform({type: 'img', width: '2000', height: '230', samples: 100000, media: file})
 
-          waveformWorker.onarne = function(error: string) {
+          waveformWorker.onerror = function(error: string) {
             setWaveformWorkerError(true)
             console.log("Waveform could not be generated:" + error)
           }

--- a/src/util/waveform.js
+++ b/src/util/waveform.js
@@ -47,7 +47,8 @@ export function Waveform(opts) {
       })
       .catch((e) => {
         console.log("Waveform Worker: " + e);
-        this.onarne = e.toString();
+        this._error = e.toString()
+        this.onerror.forEach(fn => fn(e.toString()));
       });
   }
 
@@ -69,17 +70,20 @@ export function Waveform(opts) {
   });
 
   var _error = "";
-  Object.defineProperty(this, 'onarne', {
+  var _errorFuncs = [];
+  Object.defineProperty(this, 'onerror', {
     get: function() {
-      return _error;
+      return _errorFuncs;
     },
     set: function(fn, opt) {
       if (typeof fn == 'function') {
-        fn(_error);
-      } else {
-        _error = fn
+        if (this._error && this._error !== "") {
+          fn(_error);
+          return;
+        }
       }
-      return;
+
+      _errorFuncs.push(fn);
     }
   });
 }


### PR DESCRIPTION
The error callback for the waveform generation was not working as a proper callback, but would always throw an error. By coincidence, this was hardly noticable on shorter videos, but very noticable on longer ones.

This fixes the callback. "Generating waveform" should now be displayed up until the waveform shows up, even on longer videos. In case of an error (e.g. when the video has no audio), "Waveform could not be generated" will still show.