### PR TITLE
Added readonly as metadata config option

### DIFF
--- a/public/editor-settings.toml
+++ b/public/editor-settings.toml
@@ -20,23 +20,31 @@ password = "opencast"
 [metadata]
 # If false, the metadata button is not displayed in the main menu
 show = true
-## Configure metadata display
-## Here you can set which metadata fields should be displayed in the editor
-## for each catalog.
-## If the catalog is not specified, all fields of that catalog will be
+## Here you can override various settings for how the metadata will be
+## displayed in the editor, for each catalog.
+## Setting #1: show (boolean)
+## Whether the field should be visible at all
+## Setting #2: readonly (boolean)
+## Whether the field should be editable by the user
+## If you don't configure a setting for a field, a default will be assumed.
+## The default settings are based on the metadata display in the admin ui
+## in Opencast, which can currently be configured in:
+## org.opencastproject.ui.metadata.CatalogUIAdapterFactory-episode-common.cfg
+## Furthermore:
+## If a catalog is not specified, all fields of that catalog will be
 ## displayed.
-## If the catalog is specified but empty, it will not be displayed at all.
-## If the catalog is specified with at least one field, only the fields
-## specified for the catalog will be displayed.
-[metadata.showFields]
+## If a catalog is specified but empty, it will not be displayed at all.
 ## Example definition
 # # This is the default catalog
-# "EVENTS.EVENTS.DETAILS.CATALOG.EPISODE" = [
-#   "title",
-#   "language",
-#   "duration"
-# ]
-# "NameOfAnExtendedMetadataCatalog" = []
+# [metadata.configureFields."EVENTS.EVENTS.DETAILS.CATALOG.EPISODE"]
+# title = {show = true, readonly = false}
+# subject = {show = false}
+# description = {readonly = true}
+
+# # This catalog is specified but empty, and as such will not be displayed
+# [metadata.configureFields."NameOfAnExtendedMetadataCatalog"]
+
+
 
 ### Settings of the thumbnail tab
 [thumbnail]

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,14 @@ const SRC_SERVER = 'src-server';
 const SRC_URL = 'src-url';
 
 /**
+ * Possible configuration values for a metadata catalog field
+ */
+export interface configureFieldsAttributes {
+  show: boolean,
+  readonly: boolean,
+}
+
+/**
  * Settings interface
  */
 interface iSettings {
@@ -29,7 +37,7 @@ interface iSettings {
   },
   metadata: {
     show: boolean,
-    showFields: { [key: string]: string[]; } | undefined,
+    configureFields: { [key: string]: { [key: string]: configureFieldsAttributes } }  | undefined,
   },
   thumbnail: {
     show: boolean,
@@ -52,7 +60,7 @@ var defaultSettings: iSettings = {
   },
   metadata: {
     show: true,
-    showFields: undefined,
+    configureFields: undefined,
   },
   thumbnail: {
     show: true,
@@ -237,17 +245,25 @@ const types = {
       throw new Error("is not a boolean");
     }
   },
-  'objectWithStringArrays': (v: any, allowParse: any) => {
-    for (let key in v) {
-      if (typeof key !== 'string') {
+  'objectsWithinObjects': (v: any, allowParse: any) => {
+    for (let catalogName in v) {
+      if (typeof catalogName !== 'string') {
         throw new Error("is not a string, but should be");
       }
-      if (!Array.isArray(v[key])) {
-        throw new Error("is not an array, but should be");
-      }
-      for (let item in v[key]) {
-        if (typeof item !== 'string') {
+      for (let fieldName in v[catalogName]) {
+        if (typeof fieldName !== 'string') {
           throw new Error("is not a string, but should be");
+        }
+        for (let attributeName in v[catalogName][fieldName]) {
+          if (typeof attributeName !== 'string') {
+            throw new Error("is not a string, but should be");
+          }
+          if (attributeName === 'show' && typeof v[catalogName][fieldName][attributeName] !== 'boolean') {
+            throw new Error("is not a boolean");
+          }
+          if (attributeName === 'readonly' && typeof v[catalogName][fieldName][attributeName] !== 'boolean') {
+            throw new Error("is not a boolean");
+          }
         }
       }
     }
@@ -273,7 +289,7 @@ const SCHEMA = {
   },
   metadata: {
     show : types.boolean,
-    showFields: types.objectWithStringArrays,
+    configureFields: types.objectsWithinObjects,
   },
   thumbnail: {
     show : types.boolean,

--- a/src/redux/metadataSlice.ts
+++ b/src/redux/metadataSlice.ts
@@ -100,6 +100,9 @@ const metadataSlice = createSlice({
       state.catalogs[action.payload.catalogIndex].fields[action.payload.fieldIndex].value = action.payload.value
       state.hasChanges = true
     },
+    setFieldReadonly: (state, action: any) => {
+      state.catalogs[action.payload.catalogIndex].fields[action.payload.fieldIndex].readOnly = action.payload.value
+    },
     setHasChanges: (state, action: PayloadAction<metadata["hasChanges"]>) => {
       state.hasChanges = action.payload
     }
@@ -136,7 +139,7 @@ const metadataSlice = createSlice({
   }
 })
 
-export const { setFieldValue, setHasChanges } = metadataSlice.actions
+export const { setFieldValue, setHasChanges, setFieldReadonly } = metadataSlice.actions
 
 export const selectCatalogs = (state: { metadataState: { catalogs: metadata["catalogs"] } }) =>
   state.metadataState.catalogs


### PR DESCRIPTION
Each field in a metadata catalog can now be set to be editable by the user or not.

Furthermore, this reworks how settings are written in the editor-settings.toml to allow specifiying multiple attributes for one metadata field. If an attribute is not specified, a default is assumed instead.

To test this, play around with example definitions in the editor-settings.toml and observe how they change the metadata ui.