### PR TITLE
Simplify Release Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ The editor can be configured through the `editor-settings.toml` settings file. I
 How to cut a release for Opencast
 -------------
 - Run `build-release.sh` in the root folder
-- Remove the editor-settings.toml in the created .tar archive
 - Upload the archive as a new release to GitHub
   - Release tag is the current date (year-month-day)
   - Check the commit history for notable changes and list them as a release comment

--- a/build-release.sh
+++ b/build-release.sh
@@ -8,5 +8,7 @@ npm run build
 
 FILENAME="oc-editor-$(date --utc +%F).tar.gz"
 cd build
+TMP="$(mktemp)"
+mv editor-settings.toml "$TMP"
 tar -czf ../$FILENAME *
-cd ..
+mv "$TMP" editor-settings.toml


### PR DESCRIPTION
This patch simplifies the release script by removing the necessity for
manually editing the resulting tarball.