### PR TITLE
Disallow Overwriting Opencast Parameters

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -93,10 +93,13 @@ export const init = async () => {
   var urlParams = new URLSearchParams(window.location.search);
 
   let rawUrlSettings = {};
-  urlParams.forEach(function(value, key) {
+  urlParams.forEach((value, key) => {
     // Create empty objects for full path (if the key contains '.') and set
     // the value at the end.
     let obj : {[k: string]: any} = rawUrlSettings;
+    if (key.startsWith('opencast.')) {
+      return;
+    }
     const segments = key.split('.');
     segments.slice(0, -1).forEach((segment) => {
       if (!(segment in obj)) {


### PR DESCRIPTION
This patch prevents users from crafting URLs which would make the editor
reach out to a non-configured Opencast, potentially misleading users:

    https://opencast.uni-osnabrueck.de/editor-ui/index.html?mediaPackageId=b8d2e0a3-d447-4cd1-94e5-facbc2249f22&someOther=LongAndConfusingParameter&opencast.url=https://malicious.opencast.org

…will not work any longer.