### PR TITLE
Link Documentation Directly

### DIFF
--- a/src/main/Landing.tsx
+++ b/src/main/Landing.tsx
@@ -47,7 +47,9 @@ import { useTranslation } from 'react-i18next';
         </li>
         <li>
           {t("landing.link-to-documentation")}
-          <a href="https://docs.opencast.org/stable/admin/">docs.opencast.org</a>
+          <a href="https://docs.opencast.org/stable/admin/modules/editor/">
+            docs.opencast.org
+          </a>
         </li>
       </div>
     </div>


### PR DESCRIPTION
This patch adds a direct link to the video editor documentation in
Opencast instead of just linking the main docs page.