### PR TITLE
Send POST request sequentially

### DIFF
--- a/src/main/Save.tsx
+++ b/src/main/Save.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 import { css } from '@emotion/react'
 import { basicButtonStyle, backOrContinueStyle, ariaLive, errorBoxStyle,
@@ -79,6 +79,7 @@ export const SaveButton: React.FC<{}> = () => {
   const tracks = useSelector(selectTracks)
   const workflowStatus = useSelector(selectStatus);
   const metadataStatus = useSelector(selectPostStatus);
+  const [metadataSaveStarted, setMetadataSaveStarted] = useState(false);
 
   // Update based on current fetching status
   let icon = faSave
@@ -104,13 +105,27 @@ export const SaveButton: React.FC<{}> = () => {
     }
   }
 
+  // Dispatches first save request
+  // Subsequent save requests should be wrapped in useEffect hooks,
+  // so they are only sent after the previous one has finished
   const save = () => {
+    setMetadataSaveStarted(true)
     dispatch(postMetadata())
-    dispatch(postVideoInformation({
-      segments: segments,
-      tracks: tracks,
-    }))
   }
+
+  // Subsequent save request
+  useEffect(() => {
+    if (metadataStatus === 'success' && metadataSaveStarted) {
+      setMetadataSaveStarted(false)
+      console.log("EDIT")
+      dispatch(postVideoInformation({
+        segments: segments,
+        tracks: tracks,
+      }))
+
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [metadataStatus])
 
   // Let users leave the page without warning after a successful save
   useEffect(() => {

--- a/src/main/WorkflowConfiguration.tsx
+++ b/src/main/WorkflowConfiguration.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 
 import { css } from '@emotion/react'
 import { basicButtonStyle, backOrContinueStyle, errorBoxStyle, flexGapReplacementStyle } from '../cssStyles'
@@ -75,6 +75,7 @@ export const SaveAndProcessButton: React.FC<{text: string}> = ({text}) => {
   const tracks = useSelector(selectTracks)
   const workflowStatus = useSelector(selectStatus);
   const metadataStatus = useSelector(selectPostStatus);
+  const [metadataSaveStarted, setMetadataSaveStarted] = useState(false);
 
   // Let users leave the page without warning after a successful save
   useEffect(() => {
@@ -84,14 +85,26 @@ export const SaveAndProcessButton: React.FC<{text: string}> = ({text}) => {
     }
   }, [dispatch, metadataStatus, workflowStatus])
 
+  // Dispatches first save request
+  // Subsequent save requests should be wrapped in useEffect hooks,
+  // so they are only sent after the previous one has finished
   const saveAndProcess = () => {
+    setMetadataSaveStarted(true)
     dispatch(postMetadata())
-    dispatch(postVideoInformationWithWorkflow({
-      segments: segments,
-      tracks: tracks,
-      workflow: [{id: workflows[selectedWorkflowIndex].id}],
-    }))
   }
+
+  // Subsequent save request
+  useEffect(() => {
+    if (metadataStatus === 'success' && metadataSaveStarted) {
+      setMetadataSaveStarted(false)
+      dispatch(postVideoInformationWithWorkflow({
+        segments: segments,
+        tracks: tracks,
+        workflow: [{id: workflows[selectedWorkflowIndex].id}],
+      }))
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [metadataStatus])
 
   // Update based on current fetching status
   let icon = faFileExport


### PR DESCRIPTION
The multiple post requests that are send when saving or starting processing are now sent sequentially. Requests wait for their previous requests to return with a successful response code.

This change is supposed to help avoid race conditions than seemingly occur when sending post requests to the metadata and editor endpoints in Opencast at the same time.  Therefore this hopefully resolves #353 resolves #354 resolves #363. It might be worth to look at why exactly these errors occur in the backend.