### PR TITLE
Fix metadata select fields to actually not accept input when set to readonly

### DIFF
--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -506,8 +506,10 @@ const Metadata: React.FC<{}> = () => {
           <CreatableSelect {...input}
             onBlur={e => {blurWithSubmit(e, input)}}
             isMulti
-            isClearable
-            readOnly={field.readOnly}
+            isClearable={!field.readOnly}     // The component does not support readOnly, so we have to work around
+            isSearchable={!field.readOnly}    // by setting other settings
+            openMenuOnClick={!field.readOnly}
+            menuIsOpen={field.readOnly ? false : undefined}
             options={generateReactSelectLibrary(field)}
             styles={selectFieldTypeStyle}
             css={fieldTypeStyle(field.readOnly)}>
@@ -517,7 +519,10 @@ const Metadata: React.FC<{}> = () => {
         return (
           <Select {...input}
             onBlur={e => {blurWithSubmit(e, input)}}
-            readOnly={field.readOnly}
+            isClearable={!field.readOnly}     // The component does not support readOnly, so we have to work around
+            isSearchable={!field.readOnly}    // by setting other settings
+            openMenuOnClick={!field.readOnly}
+            menuIsOpen={field.readOnly ? false : undefined}
             options={generateReactSelectLibrary(field)}
             styles={selectFieldTypeStyle}
             css={fieldTypeStyle(field.readOnly)}>


### PR DESCRIPTION
The readonly attribute does not exist on <Select> elements. This PR sets various attributes for `react-select` Elements to emulate readonly behaviour.

Note: User can still remove entries from a creatable multiselect element (e.g. presenters). Fixing this probably requires work on `react-select` itself.