### PR TITLE
Display flatline in case of waveform generation error

### DIFF
--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -393,7 +393,8 @@ const Waveforms: React.FC<{}> = () => {
       );
     } else if (waveformWorkerError) {
       return (
-        <div>{"Waveform could not be generated"}</div>
+        // Display a flatline
+        <div css={{width: '100%'}}><hr/></div>
       );
     }
     else {


### PR DESCRIPTION
In many cases, a waveform generation error will be due to the video files having no audio. A flatline represents this more accurately than some text. Furthermore, users really should not have to worry about waveform generation errors in the first place.

Resolves #314