### PR TITLE
Improved highlighting of segments

### DIFF
--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -288,13 +288,17 @@ const SegmentsList: React.FC<{timelineWidth: number}> = ({timelineWidth}) => {
         css={{
           background: bgColor(segment.deleted, activeSegmentIndex === index),
           borderRadius: '5px',
-          borderStyle: activeSegmentIndex === index ? 'dashed' : 'solid',
-          borderColor: 'white',
+          borderStyle: 'solid',
+          borderColor: activeSegmentIndex === index ? 'black' : 'white',
           borderWidth: '1px',
           boxSizing: 'border-box',
           width: ((segment.end - segment.start) / duration) * 100 + '%',
           height: '230px',
           zIndex: 1,
+          "&:focus": {
+            borderWidth: '2px',
+            borderColor: 'black',
+          },
         }}>
         </div>
       ))


### PR DESCRIPTION
Replaces the outline for segments hovered by the scrubber. This should help with visual clarity (the dashed line was really not clear on that front).

Furthermore, adds an outline if the segment is in focus, as is current standard in Chrome and derivatives. This aims to help users relying on keyboard controls.

Helps with #307