### PR TITLE
GitHub Actions Concurrency

### DIFF
--- a/.github/workflows/deploy-crowdin-keys.yml
+++ b/.github/workflows/deploy-crowdin-keys.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: crowdin
+  cancel-in-progress: true
+
 jobs:
   deploy-translation-keys:
     if: github.repository_owner == 'elan-ev'

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -6,6 +6,9 @@ on:
       - opened
       - synchronize
 
+concurrency:
+  group: test.editor.opencast.org
+
 jobs:
   main:
     runs-on: ubuntu-20.04

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: editor.opencast.org
+  cancel-in-progress: true
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If multiple GitHub Actions workflows try to simultaneously deploy to the
same environment, some of them fail with conflicts. This patch that only
a single workflow accessing the same resource runs at a time.

The test deployment will wait for the other workflows to finish. The
demo deployment to editor.opencast.org and to Crowdin will cancel old
workflows since their data will be overwritten by the new workflow
anyway.