### PR TITLE
Changed font on metadata editor

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-body {
+body, textarea, input {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',


### PR DESCRIPTION
This fixes #465
Added textarea and input to index.css. Now the font and the size is the same. (It only affects metadata page)