### PR TITLE
Centered Metadata-Page

### DIFF
--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -93,6 +93,10 @@ const Metadata: React.FC<{}> = () => {
     // maxWidth: '1500px',
     // margin: '10px',
     padding: '20px',
+    marginLeft:'auto',
+    marginRight:'auto',
+    minWidth: '50%',
+    display: 'grid',
   })
 
   const fieldStyle = css({
@@ -682,7 +686,7 @@ const Metadata: React.FC<{}> = () => {
                 return renderCatalog(catalog, i, {})
               })}
 
-{/* 
+{/*
                 <div css={{display: "block", wordWrap: "normal", whiteSpace: "pre"}}>{t("metadata.submit-helpertext", { buttonName: t("metadata.submit-button") })}</div>
 
 


### PR DESCRIPTION
This fixes #464
Centered formular, also added minWidth because the formular looked too small on full-width.