### PR TITLE
Calendar and Time Input

### DIFF
--- a/src/main/Metadata.tsx
+++ b/src/main/Metadata.tsx
@@ -542,6 +542,7 @@ const Metadata: React.FC<{}> = () => {
             disabled={field.readOnly}
             dateFunsUtils={DateFnsUtils}
             showError={showErrorOnBlur}
+            autoOk={false}
           />
         </div>
       );


### PR DESCRIPTION
This may fixes #293

Commented on this Issue:
To point 1: It seems not possible, that the Modal switches to Time-Tab after selecting a Date (Couldn't find anything about that)
To point 2: It is possible, that the Modal doesn't close after selecting a Time, so you don't have to reopen and reselect the Modal, when you accidentally selected the false Time (minutes)