### PR TITLE
Fix Test Deployment

### DIFF
--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -6,9 +6,6 @@ on:
       - opened
       - synchronize
 
-concurrency:
-  group: test.editor.opencast.org
-
 jobs:
   main:
     runs-on: ubuntu-20.04
@@ -50,6 +47,12 @@ jobs:
         echo "${DEPLOY_KEY}" > ~/.ssh/id_ed25519
         chmod 600 ~/.ssh/id_ed25519
         ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+    - name: wait for previoous workflows to finish
+      uses: softprops/turnstyle@v1
+        same-branch-only: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: clone repository
       run: |


### PR DESCRIPTION
Adding concurrency groups for the test deployment caused some of the
pending jobs to be canceled as GitHub Actions only allows a single
pending workflow in a concurrency group:

> When a concurrent job or workflow is queued, if another job or
> workflow using the same concurrency group in the repository is in
> progress, the queued job or workflow will be pending. Any previously
> pending job or workflow in the concurrency group will be canceled. To
> also cancel any currently running job or workflow in the same
> concurrency group, specify cancel-in-progress: true.

This patch switches to the [Turnstyle](https://github.com/softprops/turnstyle) action instead, which will make
the job wait for previous workflows. This should have the intended effect.