### PR TITLE
Remove unused library `date-fns`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "@types/react-redux": "^7.1.22",
         "@types/yup": "^0.29.13",
         "customize-cra": "^1.0.0",
-        "date-fns": "^2.28.0",
         "deepmerge": "^4.2.2",
         "emotion": "^11.0.0",
         "emotion-normalize": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@types/react-redux": "^7.1.22",
     "@types/yup": "^0.29.13",
     "customize-cra": "^1.0.0",
-    "date-fns": "^2.28.0",
     "deepmerge": "^4.2.2",
     "emotion": "^11.0.0",
     "emotion-normalize": "^11.0.1",


### PR DESCRIPTION
This patch removes the unused `date-fns` library. We already use
`@date-io/date-fns` instead. There is no need to track and update
`date-fns` directly.